### PR TITLE
Upgrade MessagePack to version 2.4.14-alpha

### DIFF
--- a/src/AngleSharp.Performance.Utilities/AngleSharp.Performance.Utilities.csproj
+++ b/src/AngleSharp.Performance.Utilities/AngleSharp.Performance.Utilities.csproj
@@ -1,11 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MessagePack.UnityShims" Version="0.6.0" />
-  </ItemGroup>
+  <PackageReference Include="MessagePack" Version="2.4.14-alpha" />
+</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AngleSharp.Performance.Common\AngleSharp.Performance.Common.csproj" />


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades MessagePack to 2.4.14-alpha to fix vulnerabilities in current version